### PR TITLE
update to 1.5.0

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -2,9 +2,10 @@ mkdir build
 cd build
 
 cmake -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+      -D CMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
+      -D CMAKE_BUILD_TYPE=Release ^
       -D HDF5_INCLUDE_DIR=%LIBRARY_PREFIX%\include ^
       -D HDF5_LIB_PATH=%LIBRARY_PREFIX%\lib ^
-      -D CMAKE_BUILD_TYPE=Release ^
       -G "NMake Makefiles" ..
 if errorlevel 1 exit 1
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
-mkdir build && cd build
+mkdir -p build
+cd build
+
 cmake -D CMAKE_INSTALL_PREFIX=$PREFIX \
+      -D CMAKE_PREFIX_PATH=$PREFIX \
       -D CMAKE_INSTALL_RPATH=$PREFIX/lib \
       -D HDF5_INCLUDE_DIR=$PREFIX/include \
       -D HDF5_LIB_PATH=$PREFIX/lib \
@@ -10,7 +13,5 @@ cmake -D CMAKE_INSTALL_PREFIX=$PREFIX \
 make -j${CPU_COUNT}
 make install
 
-if [[ "${CONDA_BUILD_CROSS_COMPILATION}" != "1" ]]; then
 make test
-fi
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.4.14" %}
+{% set version = "1.5.0" %}
 
 package:
   name: kealib
@@ -6,10 +6,10 @@ package:
 
 source:
   url: https://github.com/ubarsc/kealib/releases/download/kealib-{{ version }}/kealib-{{ version }}.tar.gz
-  sha256: da5d4a540b34afb61665cb7b6bf284825b51464eaf2a23ccca16955e2712cab2
+  sha256: d19a0fb051019f87fe413bda76472bf4fff8fca52ede92e0ffd983caeafd05b8
 
 build:
-  number: 1
+  number: 0
   skip: True  # [win and vc<14]
   run_exports:
     # no idea.  Sticking with minor version.  C++ lib, so may need tighter.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,6 @@ requirements:
     - make  # [unix]
   host:
     - hdf5
-    - msinttypes  # [win and vc<14]
   run:
     - hdf5
 


### PR DESCRIPTION
* update to 1.5.0
* add additional PREFIX option to cmake
* verified that https is indeed not usable for kealib.org web-site