### PR TITLE
Build with latest hdf5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: d19a0fb051019f87fe413bda76472bf4fff8fca52ede92e0ffd983caeafd05b8
 
 build:
-  number: 1
+  number: 2
   skip: True  # [win and vc<14]
   run_exports:
     # no idea.  Sticking with minor version.  C++ lib, so may need tighter.
@@ -22,7 +22,7 @@ requirements:
     - cmake
     - make  # [unix]
   host:
-    - hdf5 1.12.1
+    - hdf5 {{ hdf5 }}
   run:
     - hdf5
 


### PR DESCRIPTION
keablib rebuild

**Destination channel:**  defaults

### Links

- [6127](https://anaconda.atlassian.net/browse/PKG-6127) 

### Explanation of changes:

- Bump build number 
- Use cbc pinning for hdf5

### Notes
- Staging channel to be removed before merging. 
